### PR TITLE
Bump GitHub Actions to Node 24 majors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,10 +15,10 @@ jobs:
       matrix:
         python-version: [ "3.8", "3.9", "3.10", "3.11", "3.12", "3.13", "3.14", "3.15" ]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Cache pip
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.cache/pip
           key: ${{ runner.os }}-pip-${{ matrix.python-version }}-${{ hashFiles('**/pyproject.toml', '**/setup.py') }}
@@ -26,7 +26,7 @@ jobs:
             ${{ runner.os }}-pip-${{ matrix.python-version }}-
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
           check-latest: true
@@ -49,7 +49,7 @@ jobs:
           pytest -q --maxfail=1 --cov=ismain --cov-report=xml:coverage.xml --cov-report=term-missing
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v5
         with:
           files: ./coverage.xml
           verbose: true

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -19,9 +19,9 @@ jobs:
         python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13", "3.14", "3.15"]
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: ${{ matrix.python-version }}
         allow-prereleases: true


### PR DESCRIPTION
## What

Bumps the GitHub Actions used in both workflows to their current major versions that ship the Node.js 24 runtime.

| Action | Before | After |
|---|---|---|
| actions/checkout | v4 | v5 |
| actions/cache | v4 | v5 |
| actions/setup-python | v5 | v6 |
| codecov/codecov-action | v4 | v5 |

## Why

CI was emitting deprecation warnings on every job:

> Node.js 20 actions are deprecated. Actions will be forced to run with Node.js 24 by default starting June 16th, 2026. Node.js 20 will be removed from the runner on September 16th, 2026.

The pinned majors (`checkout@v4`, `cache@v4`, `setup-python@v5`, `codecov-action@v4`) all run on Node 20. Bumping to the new majors moves onto Node 24 ahead of the forced cutover. All input keys in use (`python-version`, `allow-prereleases`, `check-latest`, cache `path`/`key`, codecov `files`/`token`/`verbose`) are unchanged across these majors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)